### PR TITLE
Added some more fish-like highlighting

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -33,11 +33,11 @@ typeset -gA FAST_HIGHLIGHT_STYLES
 : ${FAST_HIGHLIGHT_STYLES[default]:=none}
 : ${FAST_HIGHLIGHT_STYLES[unknown-token]:=fg=red,bold}
 : ${FAST_HIGHLIGHT_STYLES[reserved-word]:=fg=yellow}
-: ${FAST_HIGHLIGHT_STYLES[alias]:=fg=green}
+: ${FAST_HIGHLIGHT_STYLES[alias]:=fg=green,bold}
 : ${FAST_HIGHLIGHT_STYLES[suffix-alias]:=fg=green}
-: ${FAST_HIGHLIGHT_STYLES[builtin]:=fg=green}
+: ${FAST_HIGHLIGHT_STYLES[builtin]:=fg=green,bold}
 : ${FAST_HIGHLIGHT_STYLES[function]:=fg=green}
-: ${FAST_HIGHLIGHT_STYLES[command]:=fg=green}
+: ${FAST_HIGHLIGHT_STYLES[command]:=fg=green,bold}
 : ${FAST_HIGHLIGHT_STYLES[precommand]:=fg=green}
 : ${FAST_HIGHLIGHT_STYLES[commandseparator]:=none}
 : ${FAST_HIGHLIGHT_STYLES[hashed-command]:=fg=green}

--- a/fast-highlight
+++ b/fast-highlight
@@ -40,7 +40,7 @@ typeset -gA FAST_HIGHLIGHT_STYLES
 : ${FAST_HIGHLIGHT_STYLES[command]:=fg=green,bold}
 : ${FAST_HIGHLIGHT_STYLES[precommand]:=fg=green}
 : ${FAST_HIGHLIGHT_STYLES[commandseparator]:=none}
-: ${FAST_HIGHLIGHT_STYLES[hashed-command]:=fg=green}
+: ${FAST_HIGHLIGHT_STYLES[hashed-command]:=fg=green,bold}
 : ${FAST_HIGHLIGHT_STYLES[path]:=fg=magenta}
 : ${FAST_HIGHLIGHT_STYLES[path_pathseparator]:=}
 : ${FAST_HIGHLIGHT_STYLES[globbing]:=fg=blue,bold}


### PR DESCRIPTION
I liked the way fish added some contrast and feedback to a user's line editor input by not only highlighting with color but also using the term's bold font. It helped to differentiate recognized and valid input from nonsense.

I've simply added the bold option to a couple of the recognized term keywords like commands and builtins. I think it looks great and feels much more like the original fish highlighting features.