### PR TITLE
Allow the various styles to be collapsed and merged together.

### DIFF
--- a/-fast-collapse-colors
+++ b/-fast-collapse-colors
@@ -1,0 +1,63 @@
+# -*- mode: sh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2019 Philippe Troin (F-i-f on GitHub)
+# All rights reserved.
+#
+# The only licensing for this file follows.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+
+function -fast-collapse-colors {
+  emulate -LR zsh -o warncreateglobal -o typesetsilent
+
+  local -a regelts
+  local region eregion i start end st_fg st_bg st_other
+  for region in $@
+  do
+    regelts=(${(s: :)region})
+    start=$regelts[1]
+    end=$regelts[2]
+    st_fg=
+    st_bg=
+    st_other=
+    for eregion in $reply[@] $region
+    do
+      regelts=(${(s: :)eregion})
+      if (( regelts[1] <= start && $regelts[2] >= end ))
+      then
+	for i in ${(ps:,:)regelts[3]}; do
+	  case $i in
+	    (fg=*) st_fg=$i ;;
+	    (bg=*) st_bg=$i ;;
+	    (*)    if [[ $i != none ]]; then st_other=${st_other:+$st_other,}$i; fi ;;
+	  esac
+	done
+      fi
+    done
+    local style=$st_fg
+    style+=${st_bg:+${style:+,}$st_bg}
+    style+=${st_other:+${style:+,}$st_other}
+    if [[ -z $style ]]; then style=none; fi
+    reply+=("$start $end $style")
+  done
+}

--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -84,9 +84,24 @@ _zsh_highlight()
   if [[ $WIDGET == zle-line-finish ]] || _zsh_highlight_buffer_modified; then
       -fast-highlight-init
       -fast-highlight-process "$PREBUFFER" "$BUFFER" 0
+      (( FAST_HIGHLIGHT[collapse_colors] )) && {
+           local -a reply_copy
+          reply_copy=($reply[@])
+          reply=()
+          -fast-collapse-colors $reply_copy[@]
+      }
       (( FAST_HIGHLIGHT[use_brackets] )) && {
           _FAST_MAIN_CACHE=( $reply )
+          (( FAST_HIGHLIGHT[collapse_colors] )) && {
+              reply=()
+          }
           -fast-highlight-string-process "$PREBUFFER" "$BUFFER"
+          (( FAST_HIGHLIGHT[collapse_colors] )) && {
+              local -a reply_copy
+              reply_copy=($reply[@])
+              reply=( $_FAST_MAIN_CACHE )
+              -fast-collapse-colors $reply_copy[@]
+          }
       }
       region_highlight=( $reply )
   else
@@ -94,8 +109,18 @@ _zsh_highlight()
       if [[ "$char" = ["{([])}"] || "${FAST_HIGHLIGHT[prev_char]}" = ["{([])}"] ]]; then
           FAST_HIGHLIGHT[prev_char]="$char"
           (( FAST_HIGHLIGHT[use_brackets] )) && {
-              reply=( $_FAST_MAIN_CACHE )
+              (( FAST_HIGHLIGHT[collapse_colors] )) && {
+                  reply=()
+              } || {
+                  reply=( $_FAST_MAIN_CACHE )
+              }
               -fast-highlight-string-process "$PREBUFFER" "$BUFFER"
+              (( FAST_HIGHLIGHT[collapse_colors] )) && {
+                  local -a reply_copy
+                  reply_copy=($reply[@])
+                  reply=( $_FAST_MAIN_CACHE )
+                  -fast-collapse-colors $reply_copy[@]
+              }
               region_highlight=( $reply )
           }
       fi
@@ -308,7 +333,7 @@ zmodload zsh/parameter 2>/dev/null
 zmodload zsh/system 2>/dev/null
 
 autoload -Uz -- is-at-least fast-theme fast-read-ini-file -fast-run-git-command -fast-make-targets \
-                -fast-run-command
+                -fast-run-command -fast-collapse-colors
 autoload -Uz -- chroma/-git.ch chroma/-hub.ch chroma/-lab.ch chroma/-example.ch chroma/-grep.ch chroma/-perl.ch chroma/-make.ch \
                 chroma/-awk.ch chroma/-vim.ch chroma/-source.ch chroma/-sh.ch chroma/-docker.ch \
                 chroma/-autoload.ch chroma/-ssh.ch chroma/-scp.ch chroma/-which.ch chroma/-printf.ch \


### PR DESCRIPTION
This is to be used when some styles set the background and others set the foreground (or some other attributes, like bold).  Without the patches, the higher priority (latest applied) style takes precedence.
For example, if your style is:
```
[arguments]
double-quoted-argument = bg:cyan
[in-string]
back-or-dollar-double-quoted-argument = red
```
When you type `% echo "hello $world"`, `hello` appears with the cyan background, but `$world` has a normal background and a red foreground.
This PR allows you to optionally merge the colors: apply and set `FAST_HIGHLIGHT[collapse_colors]=1` to enjoy `$world` with a cyan background and a red foreground (if you're into these things).

The code has no extra cost until `FAST_HIGHLIGHT[collapse_colors]=1` is set to a true value.
Unfortunately, the computation cost is quadratic relative to the number of styles applied to the command line, which is why this is kept optional.
