### PR TITLE
Don't use emulate -o, but a separate seopt for zsh 4.x compatibility.

### DIFF
--- a/fast-string-highlight
+++ b/fast-string-highlight
@@ -5,7 +5,8 @@
 # $2 - BUFFER
 #
 function -fast-highlight-string-process {
-    emulate -LR zsh -o extendedglob -o warncreateglobal -o typesetsilent
+    emulate -LR zsh
+    setopt extendedglob warncreateglobal typesetsilent
 
     local -A pos_to_level level_to_pos pair_map final_pairs
     local input=$1$2 _mybuf=$1$2 __style __quoting


### PR DESCRIPTION
This is the issue I was talking about in bug #106.
