### PR TITLE
Subversion chroma

### DIFF
--- a/chroma/-subversion.ch
+++ b/chroma/-subversion.ch
@@ -43,10 +43,10 @@ chroma/-subversion.ch/parse-revision() {
 chroma/-subversion.ch/parse-target() {
     setopt local_options extendedglob warn_create_global typeset_silent
     local __wrd="$1" __start_pos="$2" __end_pos="$3" __style __start __end
-    if [[ $__wrd == *@* ]]
+    if [[ $__wrd == *@[^/]# ]]
     then
-        local place=${__wrd%@*}
-        local rev=${__wrd##*@}
+        local place=${__wrd%@[^/]#}
+        local rev=$__wrd[$(($#place+2)),$#__wrd]
         if [[ -e $place ]]; then
             local __style
             [[ -d $place ]] && __style="${FAST_THEME_NAME}path-to-dir"  ||  __style="${FAST_THEME_NAME}path"

--- a/chroma/-subversion.ch
+++ b/chroma/-subversion.ch
@@ -32,7 +32,7 @@ chroma/-subversion.ch/parse-revision() {
     setopt local_options extendedglob warn_create_global typeset_silent
     local __wrd="$1" __start_pos="$2" __end_pos="$3" __style __start __end
     case $__wrd in
-        [0-9]##)                   __style=${FAST_THEME_NAME}mathnum          ;;
+        (r|)[0-9]##)               __style=${FAST_THEME_NAME}mathnum          ;;
         (HEAD|BASE|COMITTED|PREV)) __style=${FAST_THEME_NAME}correct-subtle   ;;
         '{'[^}]##'}')              __style=${FAST_THEME_NAME}subtle-bg        ;;
         *)                         __style=${FAST_THEME_NAME}incorrect-subtle ;;


### PR DESCRIPTION
Minor fixes and tweaks for subversion chroma:
- Fix revision peg handling (can only be in last path element).
- Fix r-prefixed revision numbers.