### PR TITLE
autoload has both - and + options.

### DIFF
--- a/chroma/-autoload.ch
+++ b/chroma/-autoload.ch
@@ -42,7 +42,7 @@ local -a __results __deserialized __noshsplit
     # "starts new command", if so pass-through – chroma ends
     [[ "$__arg_type" = 3 ]] && return 2
 
-    if [[ "$__wrd" = -* ]]; then
+    if [[ "$__wrd" = [-+]* ]]; then
         # Detected option, add style for it.
         [[ "$__wrd" = --* ]] && __style=${FAST_THEME_NAME}double-hyphen-option || \
                                 __style=${FAST_THEME_NAME}single-hyphen-option


### PR DESCRIPTION
The autoload chroma can take either - or + options.
Before the patch:
![image](https://user-images.githubusercontent.com/17555212/53689549-a09ca380-3d0d-11e9-9446-32035cf44cab.png)
After applying the PR:
![image](https://user-images.githubusercontent.com/17555212/53689553-aa260b80-3d0d-11e9-9189-05e150aadba9.png)
