### PR TITLE
Highlight commands listed with a leading path prefix (eg. /usr/bin/git or bin/git).

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -550,7 +550,7 @@ typeset -ga ZLAST_COMMANDS
    (( this_word & 1 )) && {
      # !in_redirection needed particularly for exec {A}>b {C}>d
      (( !in_redirection )) && active_command=$__arg
-     _mybuf=${${aliases[$active_command]:-$active_command}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#}
+     _mybuf=${${aliases[$active_command]:-${active_command##*/}}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#}
      [[ "$_mybuf" = (#b)(FPATH+(#c0,1)=)* ]] && _mybuf="${match[1]} ${(j: :)${(s,:,)${_mybuf#FPATH+(#c0,1)=}}}"
      [[ -n ${FAST_HIGHLIGHT[chroma-${_mybuf%% *}]} ]] && {
        __list=( ${(z@)_mybuf} )
@@ -578,7 +578,7 @@ typeset -ga ZLAST_COMMANDS
      } || (( 1 ))
    } || {
      (( this_word & 8192 )) && {
-       __list=( ${(z@)${aliases[$active_command]:-$active_command}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#} )
+       __list=( ${(z@)${aliases[$active_command]:-${active_command##*/}}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#} )
        ${FAST_HIGHLIGHT[chroma-${__list[1]}]} 0 "$__arg" $_start_pos $_end_pos 2>/dev/null && continue
      }
    }


### PR DESCRIPTION
Current fast-s-y doesn't use chromas for commands issued with a partial or absolute path.
This PR makes sure it does.
![image](https://user-images.githubusercontent.com/17555212/53690607-bb2d4780-3d22-11e9-8a60-cac925383d08.png)
