### PR TITLE
Chroma ends, wants current word parsed as command.

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -548,6 +548,11 @@ typeset -ga ZLAST_COMMANDS
       fi
    fi
 
+   (( this_word & 8192 )) && {
+     __list=( ${(z@)${aliases[$active_command]:-${active_command##*/}}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#} )
+     ${FAST_HIGHLIGHT[chroma-${__list[1]}]} 0 "$__arg" $_start_pos $_end_pos 2>/dev/null && continue
+   }
+
    (( this_word & 1 )) && {
      # !in_redirection needed particularly for exec {A}>b {C}>d
      (( !in_redirection )) && active_command=$__arg
@@ -577,11 +582,6 @@ typeset -ga ZLAST_COMMANDS
          ${FAST_HIGHLIGHT[chroma-$active_command]} 1 "$__arg" $_start_pos $_end_pos 2>/dev/null && continue
        fi
      } || (( 1 ))
-   } || {
-     (( this_word & 8192 )) && {
-       __list=( ${(z@)${aliases[$active_command]:-${active_command##*/}}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#} )
-       ${FAST_HIGHLIGHT[chroma-${__list[1]}]} 0 "$__arg" $_start_pos $_end_pos 2>/dev/null && continue
-     }
    }
 
    expanded_path=""


### PR DESCRIPTION
When a chroma aborts (return non-zero) and modifies this_word, the
current word won't be highlighted as a command, even if this_word is set to 1.
That's because chroma processing happens after command processing.
Move the follow-up (first argument is zero) chroma processing before
the command processing.  This also allows chromas to chain.

See the `nice` chroma in PR #120 on how it's used.