### PR TITLE
Fix secondary theme recursive subcommand offset.

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -1160,7 +1160,7 @@ typeset -ga ZLAST_COMMANDS
       __idx=0
     fi
     for _mybuf in $__inputs; do
-      (( __start=${_mybuf%%;*}-__PBUFLEN, __end=${_mybuf##*;}-__PBUFLEN, __start >= 0 )) && \
+      (( __start=${_mybuf%%;*}-__PBUFLEN-1, __end=${_mybuf##*;}-__PBUFLEN, __start >= 0 )) && \
         reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${__tmp}recursive-base]}")
       # Pass authentic buffer for recursive analysis
       -fast-highlight-process "$PREBUFFER" "${__buf[${_mybuf%%;*},${_mybuf##*;}]}" $(( ${_mybuf%%;*} - 1 ))


### PR DESCRIPTION
The secondary theme is applied two characters after the end of the $( string,
it should start immediately (one character) after $(.

For example, on master:
![image](https://user-images.githubusercontent.com/17555212/54390163-10405600-465f-11e9-9900-e138f455bb9a.png)

With this PR applied:
![image](https://user-images.githubusercontent.com/17555212/54390282-54cbf180-465f-11e9-8136-5d3ab2a7f414.png)
