### PR TITLE
Added support for colormake

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -172,6 +172,7 @@ FAST_HIGHLIGHT+=(
   chroma-example       chroma/-example.ch
   chroma-ionice        chroma/-ionice.ch
   chroma-make          chroma/-make.ch
+  chroma-colormake     chroma/-make.ch
   chroma-nice          chroma/-nice.ch
   chroma-nmcli         chroma/-nmcli.ch
   chroma-node          chroma/-node.ch


### PR DESCRIPTION
[colormake](https://github.com/pagekite/Colormake) is a wrapper around make to colorize it's output. I added support for highlighting targets and such by using the existing make highlighting functions.