### PR TITLE
Fix highlighting lost issues with tab completions and stack pop

### DIFF
--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -144,7 +144,6 @@ _zsh_highlight()
 
   } always {
     typeset -g _ZSH_HIGHLIGHT_PRIOR_BUFFER="$BUFFER"
-    typeset -g _ZSH_HIGHLIGHT_PRIOR_RACTIVE="$REGION_ACTIVE"
     typeset -gi _ZSH_HIGHLIGHT_PRIOR_CURSOR=$CURSOR
   }
 }
@@ -222,6 +221,10 @@ _zsh_highlight_call_widget()
 }
 
 # Rebind all ZLE widgets to make them invoke _zsh_highlights.
+autoload -U add-zle-hook-widget
+if [[ -o zle ]]; then
+  add-zle-hook-widget zle-line-init _zsh_highlight
+fi
 _zsh_highlight_bind_widgets()
 {
   setopt localoptions noksharrays

--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -209,6 +209,17 @@ _zsh_highlight_cursor_moved()
 # Setup functions
 # -------------------------------------------------------------------------------------------------
 
+autoload -U add-zle-hook-widget
+autoload -Uz is-at-least
+
+# Apply syntax highlighting on init. Fixes the issue
+# where coming back from push-line loses highlighting
+if is-at-least 5.8.0.2; then
+  if [[ -o zle ]]; then
+    add-zle-hook-widget zle-line-init _zsh_highlight
+  fi
+fi
+
 # Helper for _zsh_highlight_bind_widgets
 # $1 is name of widget to call
 _zsh_highlight_call_widget()
@@ -221,10 +232,6 @@ _zsh_highlight_call_widget()
 }
 
 # Rebind all ZLE widgets to make them invoke _zsh_highlights.
-autoload -U add-zle-hook-widget
-if [[ -o zle ]]; then
-  add-zle-hook-widget zle-line-init _zsh_highlight
-fi
 _zsh_highlight_bind_widgets()
 {
   setopt localoptions noksharrays

--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -212,14 +212,6 @@ _zsh_highlight_cursor_moved()
 autoload -U add-zle-hook-widget
 autoload -Uz is-at-least
 
-# Apply syntax highlighting on init. Fixes the issue
-# where coming back from push-line loses highlighting
-if is-at-least 5.8.0.2; then
-  if [[ -o zle ]]; then
-    add-zle-hook-widget zle-line-init _zsh_highlight
-  fi
-fi
-
 # Helper for _zsh_highlight_bind_widgets
 # $1 is name of widget to call
 _zsh_highlight_call_widget()
@@ -256,6 +248,16 @@ _zsh_highlight_bind_widgets()
   # Always wrap special zle-isearch-update widget to be notified of updates in isearch.
   # This is needed because we need to disable highlighting in that case.
   widgets_to_bind+=(zle-isearch-update)
+
+  # Apply syntax highlighting on init. Fixes the issue
+  # where coming back from push-line loses highlighting
+  if is-at-least 5.4; then
+    if [[ -o zle ]]; then
+      add-zle-hook-widget zle-line-init _zsh_highlight
+    fi
+  else
+    widgets_to_bind+=(zle-line-init)
+  fi
 
   local cur_widget
   for cur_widget in $widgets_to_bind; do


### PR DESCRIPTION
This should fix #192 #183 #197

For #197 i think it's sufficient to hook `zle-line-init` to `_zsh_highlight`

as for #192 and #183 the issue appears to be gone if i remove `typeset -g _ZSH_HIGHLIGHT_PRIOR_RACTIVE="$REGION_ACTIVE"`
upon further investigation i think that line causes the highlighter to report wrong offsets (only highlights zero chars at the end) hence the color loss, I don't know what is the root cause for that but the edits here are minimal and seem to have fixed all the highlighting issues i faced