### PR TITLE
Dark versions so that comments aren't bold black on black.

### DIFF
--- a/themes/clean-dark.ini
+++ b/themes/clean-dark.ini
@@ -1,0 +1,81 @@
+[base]
+default          = none
+unknown-token    = 124,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = yellow
+here-string-text = bg:19
+here-string-var  = 185,bg:19
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = bg:55
+incorrect-subtle = bg:52
+subtle-bg        = bg:17
+secondary        = zdharma
+recursive-base   = 183
+
+[command-point]
+reserved-word  = 146
+subcommand     = 146
+alias          = 109
+suffix-alias   = 109
+global-alias   = bg:19
+builtin        = 109
+function       = 109
+command        = 109
+precommand     = 109
+hashed-command = 109
+single-sq-bracket = 109
+double-sq-bracket = 109
+double-paren   = 146
+
+[paths]
+path          = 208
+pathseparator =
+path-to-dir   = 208,underline
+globbing      = 220
+globbing-ext  = 225
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = 115
+bracket-level-2 = 177
+bracket-level-3 = 220
+
+[arguments]
+single-hyphen-option   = 185
+double-hyphen-option   = 185
+back-quoted-argument   = none
+single-quoted-argument = 147
+double-quoted-argument = 147
+dollar-quoted-argument = 147
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = 185
+; backslash or $... in "..." (i.e. variable in string)
+back-or-dollar-double-quoted-argument = 185
+
+[other]
+variable             = none
+assign               = none
+assign-array-bracket = 109
+history-expansion    = blue,bold
+
+[math]
+mathvar = blue,bold
+mathnum = 208
+matherr = 124
+
+[for-loop]
+forvar = none
+fornum = 208
+; operator
+foroper = 147
+; separator
+forsep = 109
+
+[case]
+case-input       = 109
+case-parentheses = 116
+case-condition   = bg:19

--- a/themes/default-dark.ini
+++ b/themes/default-dark.ini
@@ -1,0 +1,84 @@
+; default theme, also embedded in the source of fast-syntax-highlighting
+
+[base]
+default          = none
+unknown-token    = red,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = yellow
+here-string-text = 18
+here-string-var  = cyan,bg:18
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = 12
+incorrect-subtle = red
+subtle-separator = green
+subtle-bg        = bg:18
+secondary        = free
+; recursive-base   =
+
+[command-point]
+reserved-word  = yellow
+subcommand     = yellow
+alias          = green
+suffix-alias   = green
+global-alias   = bg:blue
+builtin        = green
+function       = green
+command        = green
+precommand     = green
+hashed-command = green
+single-sq-bracket = green
+double-sq-bracket = green
+double-paren   = yellow
+
+[paths]
+path          = magenta
+pathseparator =
+path-to-dir   = magenta,underline
+globbing      = blue,bold
+globbing-ext  = 13
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = green,bold
+bracket-level-2 = yellow,bold
+bracket-level-3 = cyan,bold
+
+[arguments]
+single-hyphen-option   = cyan
+double-hyphen-option   = cyan
+back-quoted-argument   = none
+single-quoted-argument = yellow
+double-quoted-argument = yellow
+dollar-quoted-argument = yellow
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = cyan
+; backslash or $... in "..."
+back-or-dollar-double-quoted-argument = cyan
+
+[other]
+variable             = 113
+assign               = none
+assign-array-bracket = green
+history-expansion    = blue,bold
+
+[math]
+mathvar = blue,bold
+mathnum = magenta
+matherr = red
+
+[for-loop]
+forvar = none
+fornum = magenta
+; operator
+foroper = yellow
+; separator
+forsep = yellow,bold
+
+[case]
+case-input       = green
+case-parentheses = yellow
+case-condition   = bg:blue

--- a/themes/forest-dark.ini
+++ b/themes/forest-dark.ini
@@ -1,0 +1,81 @@
+[base]
+default          = none
+unknown-token    = 124,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = yellow
+here-string-text = underline
+here-string-var  = 65,underline
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = bg:55
+incorrect-subtle = bg:52
+subtle-bg        = bg:18
+secondary        = zdharma
+recursive-base   = 183
+
+[command-point]
+reserved-word  = 186
+subcommand     = 186
+alias          = 101
+suffix-alias   = 101
+global-alias   = bg:55
+builtin        = 101
+function       = 101
+command        = 101
+precommand     = 101
+hashed-command = 101
+single-sq-bracket = 101
+double-sq-bracket = 101
+double-paren   = 186
+
+[paths]
+path          = 107
+pathseparator =
+path-to-dir   = 107,underline
+globbing      = 114
+globbing-ext  = 118
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = green,bold
+bracket-level-2 = yellow,bold
+bracket-level-3 = cyan,bold
+
+[arguments]
+single-hyphen-option   = 65
+double-hyphen-option   = 65
+back-quoted-argument   = none
+single-quoted-argument = 186
+double-quoted-argument = 186
+dollar-quoted-argument = 186
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = 65
+; backslash or $... in "..."
+back-or-dollar-double-quoted-argument = 65
+
+[other]
+variable             = none
+assign               = none
+assign-array-bracket = 101
+history-expansion    = 114
+
+[math]
+mathvar = 114
+mathnum = 107
+matherr = 124
+
+[for-loop]
+forvar = none
+fornum = 107
+; operator
+foroper = 186
+; separator
+forsep = 109
+
+[case]
+case-input       = 101
+case-parentheses = 65
+case-condition   = underline

--- a/themes/free-dark.ini
+++ b/themes/free-dark.ini
@@ -1,0 +1,81 @@
+[base]
+default          = none
+unknown-token    = red,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = yellow
+here-string-text = bg:19
+here-string-var  = 110,bg:19
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = bg:55
+incorrect-subtle = bg:52
+subtle-bg        = bg:18
+secondary        = zdharma
+recursive-base   = 183
+
+[command-point]
+reserved-word  = 150
+subcommand     = 150
+alias          = 180
+suffix-alias   = 180
+global-alias   = bg:19
+builtin        = 180
+function       = 180
+command        = 180
+precommand     = 180
+hashed-command = 180
+single-sq-bracket = 180
+double-sq-bracket = 180
+double-paren   = 150
+
+[paths]
+path          = 166
+pathseparator =
+path-to-dir   = 166,underline
+globbing      = 112
+globbing-ext  = 118
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = 130
+bracket-level-2 = 70
+bracket-level-3 = 69
+
+[arguments]
+single-hyphen-option   = 110
+double-hyphen-option   = 110
+back-quoted-argument   = none
+single-quoted-argument = 150
+double-quoted-argument = 150
+dollar-quoted-argument = 150
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = 110
+; backslash or $... in "..." (i.e. variable inside a string)
+back-or-dollar-double-quoted-argument = 110
+
+[other]
+variable             = none
+assign               = none
+assign-array-bracket = 180
+history-expansion    = blue,bold
+
+[math]
+mathvar = blue,bold
+mathnum = 166
+matherr = red
+
+[for-loop]
+forvar = none
+fornum = 150
+; operator
+foroper = 150
+; separator
+forsep = 109
+
+[case]
+case-input       = 180
+case-parentheses = 116
+case-condition   = bg:19

--- a/themes/safari-dark.ini
+++ b/themes/safari-dark.ini
@@ -1,0 +1,83 @@
+; Light theme with colors of a Sahara oasis
+
+[base]
+default          = none
+unknown-token    = red,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = yellow
+here-string-text = bg:19
+here-string-var  = 153,bg:19
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = bg:55
+incorrect-subtle = bg:52
+subtle-bg        = bg:18
+secondary        = zdharma
+recursive-base   = 183
+
+[command-point]
+reserved-word  = 150
+subcommand     = 150
+alias          = 185
+suffix-alias   = 185
+global-alias   = bg:19
+builtin        = 185
+function       = 185
+command        = 185
+precommand     = 185
+hashed-command = 185
+single-sq-bracket = 185
+double-sq-bracket = 185
+double-paren   = 150
+
+[paths]
+path          = 187
+pathseparator =
+path-to-dir   = 187,underline
+globbing      = 180
+globbing-ext  = 184
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = 178
+bracket-level-2 = 148
+bracket-level-3 = 141
+
+[arguments]
+single-hyphen-option   = 152
+double-hyphen-option   = 152
+back-quoted-argument   = none
+single-quoted-argument = 151
+double-quoted-argument = 151
+dollar-quoted-argument = 151
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = 153
+; backslash or $... in "..." (i.e. variable inside a string)
+back-or-dollar-double-quoted-argument = 153
+
+[other]
+variable             = none
+assign               = none
+assign-array-bracket = 185
+history-expansion    = blue,bold
+
+[math]
+mathvar = blue,bold
+mathnum = 187
+matherr = red
+
+[for-loop]
+forvar = none
+fornum = 187
+; operator
+foroper = 151
+; separator
+forsep = 109
+
+[case]
+case-input       = 185
+case-parentheses = 116
+case-condition   = bg:19

--- a/themes/spa-dark.ini
+++ b/themes/spa-dark.ini
@@ -1,0 +1,82 @@
+; 144, 187, 110, 203
+[base]
+default          = none
+unknown-token    = 196
+commandseparator = 150
+redirection      = none
+here-string-tri  = yellow
+here-string-text = bg:19
+here-string-var  = 186,bg:19
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = bg:55
+incorrect-subtle = bg:52
+subtle-bg        = bg:17
+secondary        = zdharma
+recursive-base   = 183
+
+[command-point]
+reserved-word  = 144
+subcommand     = 144
+alias          = 187
+suffix-alias   = 187
+global-alias   = bg:19
+builtin        = 150
+function       = 187
+command        = 187
+precommand     = 187
+hashed-command = 187
+single-sq-bracket = 150
+double-sq-bracket = 150
+double-paren   = 144
+
+[paths]
+path          = 110
+pathseparator =
+path-to-dir   = 110,underline
+globbing      = 220
+globbing-ext  = 225
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = 115
+bracket-level-2 = 177
+bracket-level-3 = 220
+
+[arguments]
+single-hyphen-option   = 185
+double-hyphen-option   = 185
+back-quoted-argument   = none
+single-quoted-argument = 110
+double-quoted-argument = 110
+dollar-quoted-argument = 110
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = 186
+; backslash or $... in "..." (i.e. variable in string)
+back-or-dollar-double-quoted-argument = 186
+
+[other]
+variable             = none
+assign               = none
+assign-array-bracket = 187
+history-expansion    = blue,bold
+
+[math]
+mathvar = 150
+mathnum = 110
+matherr = 196
+
+[for-loop]
+forvar = 71
+fornum = 110
+; operator
+foroper = 203
+; separator
+forsep = 147
+
+[case]
+case-input       = 187
+case-parentheses = 116
+case-condition   = bg:19

--- a/themes/z-shell-dark.ini
+++ b/themes/z-shell-dark.ini
@@ -1,0 +1,81 @@
+[base]
+default          = none
+unknown-token    = red,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = 141
+here-string-text = bg:19
+here-string-var  = 45,bg:19
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = bg:55
+incorrect-subtle = bg:52
+subtle-bg        = bg:17
+secondary        = safari
+recursive-base   = 184
+
+[command-point]
+reserved-word  = 48
+reserved-word  = 48
+alias          = 93
+suffix-alias   = 93
+global-alias   = bg:19
+builtin        = 93
+function       = 93
+command        = 93
+precommand     = 93
+hashed-command = 93
+single-sq-bracket = 93
+double-sq-bracket = 93
+double-paren   = 48
+
+[paths]
+path          = 82
+pathseparator =
+path-to-dir   = 82,underline
+globbing      = 200
+globbing-ext  = 135
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = 165
+bracket-level-2 = 226
+bracket-level-3 = 50
+
+[arguments]
+single-hyphen-option   = 45
+double-hyphen-option   = 45
+back-quoted-argument   = none
+single-quoted-argument = 48
+double-quoted-argument = 48
+dollar-quoted-argument = 48
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = 45
+; backslash or $... in "..."
+back-or-dollar-double-quoted-argument = 45
+
+[other]
+variable             = none
+assign               = none
+assign-array-bracket = 93
+history-expansion    = blue,bold
+
+[math]
+mathvar = blue,bold
+mathnum = 82
+matherr = red
+
+[for-loop]
+forvar = none
+fornum = 82
+; operator
+foroper = 48
+; separator
+forsep = 111
+
+[case]
+case-input       = 93
+case-parentheses = 141
+case-condition   = bg:19

--- a/themes/zdharma-dark.ini
+++ b/themes/zdharma-dark.ini
@@ -1,0 +1,81 @@
+[base]
+default          = none
+unknown-token    = red,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = 141
+here-string-text = bg:19
+here-string-var  = 177,bg:19
+exec-descriptor  = yellow,bold
+comment = 030
+correct-subtle   = bg:55
+incorrect-subtle = bg:52
+subtle-bg        = bg:17
+secondary        = safari
+recursive-base   = 186
+
+[command-point]
+reserved-word  = 146
+reserved-word  = 146
+alias          = 63
+suffix-alias   = 63
+global-alias   = bg:19
+builtin        = 63
+function       = 63
+command        = 63
+precommand     = 63
+hashed-command = 63
+single-sq-bracket = 63
+double-sq-bracket = 63
+double-paren   = 146
+
+[paths]
+path          = 154
+pathseparator =
+path-to-dir   = 154,underline
+globbing      = 114
+globbing-ext  = 153
+
+[brackets]
+paired-bracket = bg:blue
+bracket-level-1 = 117
+bracket-level-2 = 141
+bracket-level-3 = 90
+
+[arguments]
+single-hyphen-option   = 177
+double-hyphen-option   = 177
+back-quoted-argument   = none
+single-quoted-argument = 146
+double-quoted-argument = 146
+dollar-quoted-argument = 146
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = 177
+; backslash or $... in "..."
+back-or-dollar-double-quoted-argument = 177
+
+[other]
+variable             = none
+assign               = none
+assign-array-bracket = 63
+history-expansion    = blue,bold
+
+[math]
+mathvar = blue,bold
+mathnum = 154
+matherr = red
+
+[for-loop]
+forvar = none
+fornum = 154
+; operator
+foroper = 146
+; separator
+forsep = 109
+
+[case]
+case-input       = 63
+case-parentheses = 141
+case-condition   = bg:19


### PR DESCRIPTION
# Pull request template

Adding dark variations of themes that don't use Bold Black as the comment color.  So my sanity can remain intact.

## Type of changes

- [x] Other (please describe):  as above.

## What is the current behavior?

When using the majority of themes, the comment color is set to Bold, Black,  this leads to  temporary insanity where I will begin chewing the walls and screaming like a monkey.

## What is the new behavior?

New themes are available for dark background users. These calm me and I can enjoy my terminal.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

It introduces an unbreaking change.

## Other information

I don't always comment, but when I do, I prefer them not to look like a long series of spaces.

Thank you.